### PR TITLE
Prevent overlapping of backend header and live preview controls.

### DIFF
--- a/dist/css/cp.css
+++ b/dist/css/cp.css
@@ -1,6 +1,9 @@
 .show-env-bar .z-1000 {
   z-index: 1000;
 }
+.show-env-bar .live-preview {
+  padding-top: 88px;
+}
 @media (min-width: 768px) {
   .show-env-bar #main {
     padding-top: 88px;

--- a/resources/sass/cp.scss
+++ b/resources/sass/cp.scss
@@ -2,9 +2,12 @@
   .z-1000 {
     z-index: 1000;
   }
+  .live-preview {
+    top: 88px;
+  }
   @media (min-width: 768px) {
-      #main {
-          padding-top: 88px;
-      }
+    #main {
+      padding-top: 88px;
+    }
   }
 }


### PR DESCRIPTION
When using the Live Preview feature in the backend, the fixed header was overlapping the live preview area.
<img width="1832" alt="image" src="https://user-images.githubusercontent.com/2184676/160432557-29d9ea3e-d96c-443a-8705-5c40cf937d8f.png">

By moving the live preview area down, this can be avoided.
<img width="1830" alt="image" src="https://user-images.githubusercontent.com/2184676/160432618-3f3fb0fe-d6a3-4c35-a312-6d4b88b5dd96.png">

Without the statamic-environment-bar extension, the header gets covered by the live preview control bar. With this change the header maintains visible and the live preview is not cut off.

Due to a webpack-cli error I wasn't able to run `npm run production`, therefore I added the changes manually to `dist/css/cp.css`.